### PR TITLE
refactor: unify prefix helpers across training and eval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,157 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands for Development
+
+### Running Training & Evaluation Pipeline
+```bash
+# Main pipeline script - handles training and evaluation
+bash scripts/run_pipeline.sh
+
+# Key environment variables to set before running:
+export PYTORCH_ENABLE_MPS_FALLBACK=1  # For Mac MPS
+export PYTHONPATH=.
+
+# Common training command:
+python latentwire/train.py \
+  --llama_id "meta-llama/Meta-Llama-3.1-8B-Instruct" \
+  --qwen_id "Qwen/Qwen2.5-7B-Instruct" \
+  --samples 87599 \
+  --epochs 24 \
+  --batch_size 64 \
+  --latent_len 32 \
+  --d_z 256 \
+  --encoder_type byte \
+  --dataset squad \
+  --sequential_models \
+  --warm_anchor_text "Answer: " \
+  --first_token_ce_weight 0.5
+
+# Common evaluation command:
+python latentwire/eval.py \
+  --ckpt runs/{RUN_NAME}/epoch{N} \
+  --samples 200 \
+  --max_new_tokens 12 \
+  --dataset squad \
+  --sequential_eval \
+  --fresh_eval \
+  --calibration embed_rms \
+  --latent_anchor_mode text \
+  --latent_anchor_text "Answer: " \
+  --append_bos_after_prefix yes
+```
+
+### Testing & Validation
+```bash
+# Run sanity checks for tokenization alignment
+python -c "from latentwire.train import _assert_t0_alignment; _assert_t0_alignment('meta-llama/Meta-Llama-3.1-8B-Instruct')"
+
+# Quick smoke test
+python latentwire/eval.py --ckpt {checkpoint} --samples 10 --debug
+```
+
+## High-Level Architecture
+
+### Core System Design
+LatentWire implements a **continuous interlingua** - a learned compressed representation that can condition multiple heterogeneous LLMs (Llama and Qwen) without retokenizing text. Key insights:
+
+1. **Frozen LLMs**: The base models (Llama, Qwen) remain completely frozen. Only small adapters and an encoder are trained.
+
+2. **Shared Latent Space**: A single encoder produces `Z ∈ R^{M × d_z}` soft tokens that both models consume via `inputs_embeds`.
+
+3. **Model-Specific Adapters**: Small linear adapters map the shared latent into each model's embedding space while preserving statistical properties.
+
+### Key Training Innovations
+
+#### Phase A Improvements (from PLAN.md)
+- **K-token teacher-forced CE** (`k_token_ce_from_prefix` in losses.py): Supervises first K tokens instead of just one
+- **Prefix KD** (`kd_first_k_prefix_vs_text`): Distills text-prompted teacher distributions
+- **Proper tokenization alignment**: Ensures exact t=0 alignment after anchor text
+- **Per-example calibration**: Scales latents to match embedding RMS per example
+
+#### Critical Bug Fixes (from LOG.md)
+- **PAD token masking**: Fixed gradient contamination from left-padded tokens
+- **BOS policy alignment**: Consistent BOS handling between train and eval
+- **Anchor text consistency**: Same "Answer: " anchor used throughout
+
+### Module Organization
+
+```
+latentwire/
+├── train.py          # Main training loop with K-token objectives
+├── eval.py           # Deterministic evaluation with multiple baselines
+├── losses.py         # K-token CE and KD losses (critical for learning)
+├── models.py         # Encoder, Adapter, LMWrapper classes
+├── prefix_utils.py   # Calibration, BOS policy, anchor handling
+├── data.py          # Dataset loading (SQuAD, HotpotQA)
+├── metrics.py       # EM/F1 scoring, NLL computation
+└── common.py        # Chat templates, text truncation utilities
+```
+
+### Key Configuration Parameters
+
+Critical hyperparameters that significantly impact performance:
+
+```python
+# Latent dimensions
+LATENT_LEN = 32       # M: number of soft tokens (compression vs capacity tradeoff)
+D_Z = 256            # Latent dimension per token
+
+# Training objectives
+K = 4                # Number of tokens to supervise (k_token_ce)
+FIRST_TOKEN_CE = 0.5 # Weight for first-token cross-entropy
+KD_TAU = 1.0        # Temperature for knowledge distillation
+
+# Calibration & anchoring
+CALIBRATION = "embed_rms"      # Scale latents to match embedding statistics
+WARM_ANCHOR_TEXT = "Answer: "  # Anchor text between prefix and answer
+APPEND_BOS_AFTER_PREFIX = "yes" # BOS policy for first-token generation
+
+# Decode hardening
+FIRST_TOKEN_TOP_P = 0.95       # Nucleus sampling for first token
+FIRST_TOKEN_TEMPERATURE = 0.7  # Temperature for first token
+EOS_BAN_STEPS = 4              # Prevent early EOS tokens
+```
+
+### Evaluation Metrics & Baselines
+
+The system evaluates against multiple baselines:
+1. **Text baseline**: Full prompt via text (upper bound)
+2. **Latent**: Compressed soft tokens
+3. **Token-budget**: Text truncated to M tokens (fairness baseline)
+4. **Joint rescoring**: Two-model ensemble picking best answer
+
+Key metrics tracked:
+- **Task quality**: EM/F1 scores
+- **Conditioning**: NLL/token on gold answers
+- **Efficiency**: Compression ratio, wire bytes, wall-clock time
+- **First-token accuracy**: Critical for generation quality
+
+### Common Pitfalls & Solutions
+
+1. **PAD token contamination**: Always mask PAD tokens (-100) in labels and zero their attention
+2. **BOS misalignment**: Ensure consistent BOS policy between train/eval
+3. **Amplitude drift**: Use per-example calibration, not batch-level
+4. **Tokenization mismatch**: Verify t=0 alignment with `_assert_t0_alignment()`
+5. **Left padding issues**: Handle properly in teacher-forced sequences
+
+### Compression & Wire Protocol
+
+The system measures honest compression via:
+- **Text bytes**: UTF-8 encoded prompt bytes
+- **Latent bytes**: Quantized latent representation (fp16/int8/int6/int4)
+- Group-wise quantization with scale overhead accounting
+- Target: ≥4× compression while maintaining quality
+
+### Current State & Next Steps
+
+Based on recent experiments (8B_clean_answer_ftce run):
+- Text baseline achieves F1 ~0.80-0.85
+- Latent currently at F1 ~0.01-0.02, FirstTok@1 ~5-7%
+- Recent fixes addressed PAD masking and BOS alignment
+- Next focus: Improving first-token accuracy via K-token objectives
+
+The codebase is actively implementing Phase A improvements from PLAN.md to achieve:
+- FirstTok@1: 12-20% at M∈{32,48,64}
+- F1: 0.10-0.20 with honest compression

--- a/latentwire/losses.py
+++ b/latentwire/losses.py
@@ -79,7 +79,7 @@ def k_token_ce_from_prefix(
 
     for t in range(min(K, A)):
         inputs_embeds = _compose_student_inputs_from_prefix(
-            llm, prefix_embeds, gold_ids, t - 1, anchor_ids, append_bos_after_prefix
+            llm, prefix_embeds, gold_ids, t, anchor_ids, append_bos_after_prefix
         )
         attn_mask = torch.ones(inputs_embeds.size()[:-1], dtype=torch.long, device=device)
         out = llm.model(inputs_embeds=inputs_embeds, attention_mask=attn_mask, use_cache=False, return_dict=True)
@@ -118,7 +118,7 @@ def kd_first_k_prefix_vs_text(
             T = F.softmax(T_logits / tau, dim=-1)
 
         inputs_embeds = _compose_student_inputs_from_prefix(
-            student_llm, prefix_embeds, gold_ids, t - 1, anchor_ids, append_bos_after_prefix
+            student_llm, prefix_embeds, gold_ids, t, anchor_ids, append_bos_after_prefix
         )
         attn_mask = torch.ones(inputs_embeds.size()[:-1], dtype=torch.long, device=device)
         out = student_llm.model(inputs_embeds=inputs_embeds, attention_mask=attn_mask, use_cache=False, return_dict=True)

--- a/latentwire/prefix_utils.py
+++ b/latentwire/prefix_utils.py
@@ -1,0 +1,154 @@
+import math
+from typing import Any, Dict, List, Optional, Sequence
+
+import torch
+
+
+def calibrate_to_embed_rms(prefix: torch.Tensor, wrapper) -> torch.Tensor:
+    """Scale each example to match the wrapper's input embedding RMS."""
+    target = prefix.new_tensor(wrapper.input_embedding_rms())
+    cur = prefix.float().pow(2).mean(dim=[1, 2], keepdim=True).sqrt().clamp_min(1e-8)
+    gain = (target / cur).to(prefix.dtype)
+    return prefix * gain
+
+
+def bos_policy(flag: str, anchor_ids: Sequence[int]) -> Optional[bool]:
+    """Resolve user BOS policy flag into a boolean understood by LMWrapper."""
+    if flag == "auto":
+        return None
+    return flag == "yes"
+
+
+def first_non_bos(tokenizer, ids: torch.Tensor) -> torch.Tensor:
+    """Return the first non-padding, non-BOS token per row."""
+    device = ids.device
+    pad = getattr(tokenizer, "pad_token_id", None)
+    bos = getattr(tokenizer, "bos_token_id", None)
+
+    if pad is None:
+        non_pad = torch.ones_like(ids, dtype=torch.bool, device=device)
+    else:
+        non_pad = ids.ne(int(pad))
+
+    first_idx = non_pad.float().argmax(dim=1)
+    row = torch.arange(ids.size(0), device=device)
+    first_tok = ids[row, first_idx]
+
+    if bos is not None:
+        is_bos = first_tok.eq(int(bos))
+        next_idx = torch.clamp(first_idx + 1, max=ids.size(1) - 1)
+        first_tok = torch.where(is_bos, ids[row, next_idx], first_tok)
+
+    return first_tok
+
+
+def build_scaffold_ids(tokenizer, texts: Sequence[str], anchor_text: str, device: str) -> torch.Tensor:
+    suffix = anchor_text or ""
+    combo = [t + suffix for t in texts]
+    enc = tokenizer(combo, return_tensors="pt", padding=True, truncation=False, add_special_tokens=True)
+    return enc["input_ids"].to(device)
+
+
+def anchor_token_ids(wrapper, text: Optional[str]) -> List[int]:
+    if text:
+        return wrapper._encode_anchor_text(text)
+    return []
+
+
+def tensor_rms(x: torch.Tensor) -> float:
+    with torch.no_grad():
+        return float(x.float().pow(2).mean().sqrt().item())
+
+
+def tensor_rms_d(x: torch.Tensor) -> torch.Tensor:
+    return x.pow(2).mean().sqrt()
+
+
+@torch.no_grad()
+def quantize_dequantize(Z: torch.Tensor, bits: Optional[int], group_size: int = 32) -> torch.Tensor:
+    """Symmetric per-group quantize/dequantize helper used at eval time."""
+    if bits is None or bits >= 16:
+        return Z
+    if bits not in (8, 6, 4):
+        raise ValueError(f"Unsupported quantization bits: {bits}")
+
+    qmax = (1 << (bits - 1)) - 1
+    flat = Z.detach().to(torch.float32).contiguous().view(-1)
+    if flat.numel() == 0:
+        return Z
+
+    out = flat.clone()
+    gs = max(1, int(group_size))
+    for start in range(0, flat.numel(), gs):
+        end = min(start + gs, flat.numel())
+        seg = flat[start:end]
+        amax = seg.abs().max()
+        scale = (amax / qmax) if float(amax) > 0.0 else torch.tensor(1e-8, dtype=seg.dtype, device=seg.device)
+        q = torch.clamp(torch.round(seg / scale), min=-qmax, max=qmax)
+        out[start:end] = q * scale
+    return out.view_as(Z).to(Z.dtype)
+
+
+def _latent_bits_count(M: int, d_latent: int, bits_per_param: int,
+                       group_size: Optional[int] = None, scale_bits: int = 16) -> int:
+    core = int(M) * int(d_latent) * int(bits_per_param)
+    overhead = 0
+    if group_size and group_size > 0:
+        groups = math.ceil((int(M) * int(d_latent)) / int(group_size))
+        overhead = groups * int(scale_bits)
+    header_bits = 8 * 16  # 16 bytes metadata/header
+    return core + overhead + header_bits
+
+
+def latent_bytes_dict(M: int, d_latent: int, group_size: int = 32, scale_bits: int = 16) -> Dict[str, int]:
+    return {
+        "fp32": math.ceil(_latent_bits_count(M, d_latent, 32) / 8),
+        "fp16": math.ceil(_latent_bits_count(M, d_latent, 16) / 8),
+        "int8": math.ceil(_latent_bits_count(M, d_latent, 8, group_size, scale_bits) / 8),
+        "int6": math.ceil(_latent_bits_count(M, d_latent, 6, group_size, scale_bits) / 8),
+        "int4": math.ceil(_latent_bits_count(M, d_latent, 4, group_size, scale_bits) / 8),
+    }
+
+
+def compute_wire_metrics(
+    llama_chat_prompts: Sequence[str],
+    qwen_chat_prompts: Sequence[str],
+    Z: torch.Tensor,
+    group_size: int = 32,
+    scale_bits: int = 16,
+    selected_bits: Optional[int] = None,
+) -> Dict[str, Any]:
+    avg_text_bytes_llama = (
+        int(sum(len(p.encode("utf-8")) for p in llama_chat_prompts) / max(1, len(llama_chat_prompts)))
+        if llama_chat_prompts else 0
+    )
+    avg_text_bytes_qwen = (
+        int(sum(len(p.encode("utf-8")) for p in qwen_chat_prompts) / max(1, len(qwen_chat_prompts)))
+        if qwen_chat_prompts else 0
+    )
+    M = int(Z.size(1))
+    d = int(Z.size(2))
+    lat_bytes = latent_bytes_dict(M, d, group_size=group_size, scale_bits=scale_bits)
+    max_onecopy = max(avg_text_bytes_llama, avg_text_bytes_qwen)
+
+    selected_key = {16: "fp16", 8: "int8", 6: "int6", 4: "int4"}.get(selected_bits)
+    selected = lat_bytes.get(selected_key) if selected_key else None
+
+    def _safe(x: Optional[int], y: int) -> Optional[float]:
+        return (float(x) / float(y)) if (x and y) else None
+
+    return {
+        "text_bytes_onecopy": {
+            "llama_avg": avg_text_bytes_llama,
+            "qwen_avg": avg_text_bytes_qwen,
+            "max_avg": max_onecopy,
+        },
+        "text_bytes_twocopies": {"sum_avg": avg_text_bytes_llama + avg_text_bytes_qwen},
+        "latent_bytes": lat_bytes,
+        "selected_latent_bytes": selected,
+        "wire_ratio": {
+            "latent_over_onecopy_fp16": _safe(lat_bytes["fp16"], max_onecopy),
+            "latent_over_onecopy_fp32": _safe(lat_bytes["fp32"], max_onecopy),
+            "selected_over_onecopy": _safe(selected, max_onecopy) if selected else None,
+        },
+    }


### PR DESCRIPTION
## Summary
- extract shared prefix utilities for calibration, anchors, quantization, and wire metrics
- refactor training loop to iterate over model contexts and centralize loss logging
- simplify evaluation to reuse common helpers and align anchor/BOS policies with training
- deduplicate pipeline flags for train/eval to keep parameters synchronized

## Testing
- source .venv/bin/activate && python -m compileall latentwire/train.py latentwire/eval.py latentwire/losses.py latentwire/prefix_utils.py