### PR TITLE
fix: enforce GPU partitioning and eos safety

### DIFF
--- a/latentwire/models.py
+++ b/latentwire/models.py
@@ -330,20 +330,26 @@ class LMWrapper(nn.Module):
                     bnb_4bit_compute_dtype=compute_dtype,
                 )
                 load_kwargs["quantization_config"] = bnb_config
+                if cfg.device_map is not None:
+                    load_kwargs["device_map"] = cfg.device_map
+                elif cfg.device == "cuda":
+                    load_kwargs.setdefault("device_map", "auto")
+                if cfg.max_memory is not None:
+                    load_kwargs["max_memory"] = cfg.max_memory
             except Exception as e:
                 print("bitsandbytes not available or failed; falling back to full precision:", e)
 
         if cfg.device == "cuda":
             if cfg.device_map is not None:
                 load_kwargs["device_map"] = cfg.device_map
-            elif "device_map" not in load_kwargs:
-                load_kwargs["device_map"] = "auto"
-            if cfg.max_memory is not None:
+            else:
+                load_kwargs.setdefault("device_map", "auto")
+            if cfg.max_memory is not None and "max_memory" not in load_kwargs:
                 load_kwargs["max_memory"] = cfg.max_memory
         else:
             if cfg.device_map is not None:
                 load_kwargs["device_map"] = cfg.device_map
-            if cfg.max_memory is not None:
+            if cfg.max_memory is not None and "max_memory" not in load_kwargs:
                 load_kwargs["max_memory"] = cfg.max_memory
 
         self.tokenizer = AutoTokenizer.from_pretrained(cfg.model_id, use_fast=True, trust_remote_code=True)

--- a/latentwire/models.py
+++ b/latentwire/models.py
@@ -2,7 +2,7 @@
 import math
 import re
 from dataclasses import dataclass
-from typing import Optional, List, Tuple, Dict, Any, Sequence, Union
+from typing import Optional, List, Tuple, Dict, Any, Sequence, Union, Set
 
 import torch
 import torch.nn as nn
@@ -333,11 +333,18 @@ class LMWrapper(nn.Module):
             except Exception as e:
                 print("bitsandbytes not available or failed; falling back to full precision:", e)
 
-        if cfg.device_map is not None:
-            load_kwargs["device_map"] = cfg.device_map
-
-        if cfg.max_memory is not None:
-            load_kwargs["max_memory"] = cfg.max_memory
+        if cfg.device == "cuda":
+            if cfg.device_map is not None:
+                load_kwargs["device_map"] = cfg.device_map
+            elif "device_map" not in load_kwargs:
+                load_kwargs["device_map"] = "auto"
+            if cfg.max_memory is not None:
+                load_kwargs["max_memory"] = cfg.max_memory
+        else:
+            if cfg.device_map is not None:
+                load_kwargs["device_map"] = cfg.device_map
+            if cfg.max_memory is not None:
+                load_kwargs["max_memory"] = cfg.max_memory
 
         self.tokenizer = AutoTokenizer.from_pretrained(cfg.model_id, use_fast=True, trust_remote_code=True)
         try:
@@ -356,8 +363,6 @@ class LMWrapper(nn.Module):
                 self.tokenizer.add_special_tokens({"pad_token": "<|pad|>"})
             self.tokenizer.eos_token = self.tokenizer.pad_token
 
-        if cfg.device == "cuda" and "device_map" not in load_kwargs:
-            load_kwargs["device_map"] = "auto"
         self.model = AutoModelForCausalLM.from_pretrained(cfg.model_id, trust_remote_code=True, **load_kwargs)
         if cfg.device in ("mps", "cpu"):
             try:
@@ -380,20 +385,21 @@ class LMWrapper(nn.Module):
     # ---- utility ----
 
     def _collect_eos_token_ids(self) -> List[int]:
-        ids = set()
-        try:
-            if self.tokenizer.eos_token_id is not None:
-                ids.add(int(self.tokenizer.eos_token_id))
-        except Exception:
-            pass
-        for tok in ["<|eot_id|>", "<|im_end|>", "</s>"]:
+        ids: Set[int] = set()
+
+        tid = getattr(self.tokenizer, "eos_token_id", None)
+        if isinstance(tid, int) and tid >= 0:
+            ids.add(int(tid))
+
+        for tok in ("<|eot_id|>", "<|im_end|>", "</s>", "<|eom_id|>", "<|endoftext|>"):
             try:
-                tid = self.tokenizer.convert_tokens_to_ids(tok)
-                if isinstance(tid, int) and tid >= 0:
-                    ids.add(int(tid))
+                token_id = self.tokenizer.convert_tokens_to_ids(tok)
             except Exception:
-                pass
-        return list(sorted(ids))
+                continue
+            if isinstance(token_id, int) and token_id >= 0:
+                ids.add(int(token_id))
+
+        return sorted(ids)
 
     def _encode_anchor_text(self, text: Optional[str]) -> List[int]:
         if not text:

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -21,6 +21,12 @@ TOKEN_BUDGET_K=32                  # match LATENT_LEN for a fairer budget
 FIRST_TOKEN_TOP_P=1.0              # deterministic first token
 FIRST_TOKEN_TEMPERATURE=0.0        # deterministic first token
 
+DETERMINISTIC_EVAL=${DETERMINISTIC_EVAL:-1}
+if [[ "$DETERMINISTIC_EVAL" -eq 1 ]]; then
+  FIRST_TOKEN_TOP_P=1.0
+  FIRST_TOKEN_TEMPERATURE=0.0
+fi
+
 # Anchor & decode controls
 LATENT_ANCHOR_MODE="text"
 LATENT_ANCHOR_TEXT="Answer: "      # note the trailing space

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -75,8 +75,11 @@ QWEN_ID="Qwen/Qwen2.5-7B-Instruct"
 
 # GPU selection
 CUDA_VISIBLE_DEVICES="0,1,2,3"
-LLAMA_DEVICE_MAP="0"
-QWEN_DEVICE_MAP="1"
+LLAMA_DEVICES="0,1"
+QWEN_DEVICES="2,3"
+GPU_MEM_GIB=78
+LLAMA_DEVICE_MAP="auto"
+QWEN_DEVICE_MAP="auto"
 
 # ------------- PATHS & RUNTIME -----------------
 
@@ -105,6 +108,7 @@ TRAIN_ARGS_COMMON=(
   --state_kd_weight "$STATE_KD_WEIGHT" --state_kd_layers "$STATE_KD_LAYERS"
   --K "$K" --k_ce_weight "$K_CE_WEIGHT" --kd_first_k_weight "$KD_FIRST_K_WEIGHT" --kd_tau "$KD_TAU"
   --llama_device_map "$LLAMA_DEVICE_MAP" --qwen_device_map "$QWEN_DEVICE_MAP"
+  --llama_devices "$LLAMA_DEVICES" --qwen_devices "$QWEN_DEVICES" --gpu_mem_gib "$GPU_MEM_GIB"
 )
 
 EVAL_ARGS_COMMON=(
@@ -121,6 +125,7 @@ EVAL_ARGS_COMMON=(
   --chunk_size "$CHUNK_SIZE"
   --sequential_eval
   --llama_device_map "$LLAMA_DEVICE_MAP" --qwen_device_map "$QWEN_DEVICE_MAP"
+  --llama_devices "$LLAMA_DEVICES" --qwen_devices "$QWEN_DEVICES" --gpu_mem_gib "$GPU_MEM_GIB"
 )
 
 # Run folder name


### PR DESCRIPTION
## Summary
- constrain LMWrapper to respect explicit device_map/max_memory and clean the stop-id collector
- add training/eval flags plus pipeline wiring to shard Llama to GPUs 0-1 and Qwen to 2-3 with configurable memory budgets
- persist GPU placement in saved configs for reproducible 4×H100 runs

## Testing
- python -m compileall latentwire
